### PR TITLE
inotify: code cleanup. Closing watcher should now always shut down goroutine

### DIFF
--- a/inotify.go
+++ b/inotify.go
@@ -118,9 +118,6 @@ func (w *Watcher) Add(name string) error {
 // Remove stops watching the named file or directory (non-recursively).
 func (w *Watcher) Remove(name string) error {
 	name = filepath.Clean(name)
-	if w.isClosed() {
-		return errors.New("inotify instance already closed")
-	}
 
 	// Fetch the watch.
 	w.mu.Lock()

--- a/inotify_test.go
+++ b/inotify_test.go
@@ -1,4 +1,4 @@
-// Copyright 2010 The Go Authors. All rights reserved.
+// Copyright 2015 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/inotify_test.go
+++ b/inotify_test.go
@@ -1,0 +1,108 @@
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux
+
+package fsnotify
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestInotifyCloseRightAway(t *testing.T) {
+	w, err := NewWatcher()
+	if err != nil {
+		t.Fatalf("Failed to create watcher")
+	}
+
+	// Close immediately; it won't even reach the first syscall.Read.
+	w.Close()
+
+	// Wait for the close to complete.
+	<-time.After(50 * time.Millisecond)
+	isWatcherReallyClosed(t, w)
+}
+
+func TestInotifyCloseSlightlyLater(t *testing.T) {
+	w, err := NewWatcher()
+	if err != nil {
+		t.Fatalf("Failed to create watcher")
+	}
+
+	// Wait until readEvents has reached syscall.Read, and Close.
+	<-time.After(50 * time.Millisecond)
+	w.Close()
+
+	// Wait for the close to complete.
+	<-time.After(50 * time.Millisecond)
+	isWatcherReallyClosed(t, w)
+}
+
+func TestInotifyCloseSlightlyLaterWithWatch(t *testing.T) {
+	testDir := tempMkdir(t)
+	defer os.RemoveAll(testDir)
+
+	w, err := NewWatcher()
+	if err != nil {
+		t.Fatalf("Failed to create watcher")
+	}
+	w.Add("testDir")
+
+	// Wait until readEvents has reached syscall.Read, and Close.
+	<-time.After(50 * time.Millisecond)
+	w.Close()
+
+	// Wait for the close to complete.
+	<-time.After(50 * time.Millisecond)
+	isWatcherReallyClosed(t, w)
+}
+
+func TestInotifyCloseAfterRead(t *testing.T) {
+	testDir := tempMkdir(t)
+	defer os.RemoveAll(testDir)
+
+	w, err := NewWatcher()
+	if err != nil {
+		t.Fatalf("Failed to create watcher")
+	}
+
+	err = w.Add(testDir)
+	if err != nil {
+		t.Fatalf("Failed to add .")
+	}
+
+	// Generate an event.
+	os.Create(filepath.Join(testDir, "somethingSOMETHINGsomethingSOMETHING"))
+
+	// Wait for readEvents to read the event, then close the watcher.
+	<-time.After(50 * time.Millisecond)
+	w.Close()
+
+	// Wait for the close to complete.
+	<-time.After(50 * time.Millisecond)
+	isWatcherReallyClosed(t, w)
+}
+
+func isWatcherReallyClosed(t *testing.T, w *Watcher) {
+	select {
+	case err, ok := <-w.Errors:
+		if ok {
+			t.Fatalf("w.Errors is not closed; readEvents is still alive after closing (error: %v)", err)
+		}
+	default:
+		t.Fatalf("w.Errors would have blocked; readEvents is still alive!")
+	}
+
+	select {
+	case _, ok := <-w.Events:
+		if ok {
+			t.Fatalf("w.Events is not closed; readEvents is still alive after closing")
+		}
+	default:
+		t.Fatalf("w.Events would have blocked; readEvents is still alive!")
+	}
+}


### PR DESCRIPTION
fixes go-fsnotify/fsnotify#3

Also fixed a racey access to w.watches in Close.

I put the tests in notify_test.go, so it doesn't break any other builds. These tests should be checked against the other platforms one by one before pulling them into integration_test.go.