### PR TITLE
kqueue: close kqueue after removing watches

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -1109,6 +1109,21 @@ func TestConcurrentRemovalOfWatch(t *testing.T) {
 	<-removed2
 }
 
+func TestClose(t *testing.T) {
+	// Regression test for #59 bad file descriptor from Close
+	testDir := tempMkdir(t)
+	defer os.RemoveAll(testDir)
+
+	watcher := newWatcher(t)
+	if err := watcher.Add(testDir); err != nil {
+		t.Fatalf("Expected no error on Add, got %v", err)
+	}
+	err := watcher.Close()
+	if err != nil {
+		t.Fatalf("Expected no error on Close, got %v.", err)
+	}
+}
+
 func testRename(file1, file2 string) error {
 	switch runtime.GOOS {
 	case "windows", "plan9":

--- a/kqueue.go
+++ b/kqueue.go
@@ -72,15 +72,19 @@ func (w *Watcher) Close() error {
 	w.isClosed = true
 	w.mu.Unlock()
 
-	// Send "quit" message to the reader goroutine:
-	w.done <- true
-
 	w.mu.Lock()
 	ws := w.watches
 	w.mu.Unlock()
+
+	var err error
 	for name := range ws {
-		w.Remove(name)
+		if e := w.Remove(name); e != nil && err == nil {
+			err = e
+		}
 	}
+
+	// Send "quit" message to the reader goroutine:
+	w.done <- true
 
 	return nil
 }


### PR DESCRIPTION
sending done would close w.kq before Remove had a chance to remove the watches with EV_DELETE, resulting in a file handle leak.

ref #59

also make Close() report last error returned by Remove.