### PR TITLE
Add Has* methods to simplify checking the state of an Event

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -25,7 +25,7 @@ func ExampleNewWatcher() {
 			select {
 			case event := <-watcher.Events:
 				log.Println("event:", event)
-				if event.Op&fsnotify.Write == fsnotify.Write {
+				if event.HasWrite() {
 					log.Println("modified file:", event.Name)
 				}
 			case err := <-watcher.Errors:

--- a/fsnotify.go
+++ b/fsnotify.go
@@ -30,25 +30,40 @@ const (
 	Chmod
 )
 
+// HasCreate returns true if Event has the Create opcode
+func (e Event) HasCreate() bool { return e.Op&Create == Create }
+
+// HasWrite returns true if Event has the Write opcode
+func (e Event) HasWrite() bool { return e.Op&Write == Write }
+
+// HasRemove returns true if Event has the Remove opcode
+func (e Event) HasRemove() bool { return e.Op&Remove == Remove }
+
+// HasRename returns true if Event has the Rename opcode
+func (e Event) HasRename() bool { return e.Op&Rename == Rename }
+
+// HasChmod returns true if Event has the Chmod opcode
+func (e Event) HasChmod() bool { return e.Op&Chmod == Chmod }
+
 // String returns a string representation of the event in the form
 // "file: REMOVE|WRITE|..."
 func (e Event) String() string {
 	// Use a buffer for efficient string concatenation
 	var buffer bytes.Buffer
 
-	if e.Op&Create == Create {
+	if e.HasCreate() {
 		buffer.WriteString("|CREATE")
 	}
-	if e.Op&Remove == Remove {
+	if e.HasRemove() {
 		buffer.WriteString("|REMOVE")
 	}
-	if e.Op&Write == Write {
+	if e.HasWrite() {
 		buffer.WriteString("|WRITE")
 	}
-	if e.Op&Rename == Rename {
+	if e.HasRename() {
 		buffer.WriteString("|RENAME")
 	}
-	if e.Op&Chmod == Chmod {
+	if e.HasChmod() {
 		buffer.WriteString("|CHMOD")
 	}
 

--- a/inotify.go
+++ b/inotify.go
@@ -277,7 +277,7 @@ func (e *Event) ignoreLinux(mask uint32) bool {
 	// *Note*: this was put in place because it was seen that a MODIFY
 	// event was sent after the DELETE. This ignores that MODIFY and
 	// assumes a DELETE will come or has come if the file doesn't exist.
-	if !(e.Op&Remove == Remove || e.Op&Rename == Rename) {
+	if !(e.HasRemove() || e.HasRename()) {
 		_, statErr := os.Lstat(e.Name)
 		return os.IsNotExist(statErr)
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -91,16 +91,16 @@ func TestFsnotifyMultipleOperations(t *testing.T) {
 			// Only count relevant events
 			if event.Name == filepath.Clean(testDir) || event.Name == filepath.Clean(testFile) {
 				t.Logf("event received: %s", event)
-				if event.Op&Remove == Remove {
+				if event.HasRemove() {
 					deleteReceived.increment()
 				}
-				if event.Op&Write == Write {
+				if event.HasWrite() {
 					modifyReceived.increment()
 				}
-				if event.Op&Create == Create {
+				if event.HasCreate() {
 					createReceived.increment()
 				}
-				if event.Op&Rename == Rename {
+				if event.HasRename() {
 					renameReceived.increment()
 				}
 			} else {
@@ -204,13 +204,13 @@ func TestFsnotifyMultipleCreates(t *testing.T) {
 			// Only count relevant events
 			if event.Name == filepath.Clean(testDir) || event.Name == filepath.Clean(testFile) {
 				t.Logf("event received: %s", event)
-				if event.Op&Remove == Remove {
+				if event.HasRemove() {
 					deleteReceived.increment()
 				}
-				if event.Op&Create == Create {
+				if event.HasCreate() {
 					createReceived.increment()
 				}
-				if event.Op&Write == Write {
+				if event.HasWrite() {
 					modifyReceived.increment()
 				}
 			} else {
@@ -343,13 +343,13 @@ func TestFsnotifyDirOnly(t *testing.T) {
 			// Only count relevant events
 			if event.Name == filepath.Clean(testDir) || event.Name == filepath.Clean(testFile) || event.Name == filepath.Clean(testFileAlreadyExists) {
 				t.Logf("event received: %s", event)
-				if event.Op&Remove == Remove {
+				if event.HasRemove() {
 					deleteReceived.increment()
 				}
-				if event.Op&Write == Write {
+				if event.HasWrite() {
 					modifyReceived.increment()
 				}
-				if event.Op&Create == Create {
+				if event.HasCreate() {
 					createReceived.increment()
 				}
 			} else {
@@ -445,7 +445,7 @@ func TestFsnotifyDeleteWatchedDir(t *testing.T) {
 			// Only count relevant events
 			if event.Name == filepath.Clean(testDir) || event.Name == filepath.Clean(testFileAlreadyExists) {
 				t.Logf("event received: %s", event)
-				if event.Op&Remove == Remove {
+				if event.HasRemove() {
 					deleteReceived.increment()
 				}
 			} else {
@@ -491,10 +491,10 @@ func TestFsnotifySubDir(t *testing.T) {
 			// Only count relevant events
 			if event.Name == filepath.Clean(testDir) || event.Name == filepath.Clean(testSubDir) || event.Name == filepath.Clean(testFile1) {
 				t.Logf("event received: %s", event)
-				if event.Op&Create == Create {
+				if event.HasCreate() {
 					createReceived.increment()
 				}
-				if event.Op&Remove == Remove {
+				if event.HasRemove() {
 					deleteReceived.increment()
 				}
 			} else {
@@ -585,7 +585,7 @@ func TestFsnotifyRename(t *testing.T) {
 		for event := range eventstream {
 			// Only count relevant events
 			if event.Name == filepath.Clean(testDir) || event.Name == filepath.Clean(testFile) || event.Name == filepath.Clean(testFileRenamed) {
-				if event.Op&Rename == Rename {
+				if event.HasRename() {
 					renameReceived.increment()
 				}
 				t.Logf("event received: %s", event)
@@ -667,7 +667,7 @@ func TestFsnotifyRenameToCreate(t *testing.T) {
 		for event := range eventstream {
 			// Only count relevant events
 			if event.Name == filepath.Clean(testDir) || event.Name == filepath.Clean(testFile) || event.Name == filepath.Clean(testFileRenamed) {
-				if event.Op&Create == Create {
+				if event.HasCreate() {
 					createReceived.increment()
 				}
 				t.Logf("event received: %s", event)
@@ -881,10 +881,10 @@ func TestFsnotifyAttrib(t *testing.T) {
 		for event := range eventstream {
 			// Only count relevant events
 			if event.Name == filepath.Clean(testDir) || event.Name == filepath.Clean(testFile) {
-				if event.Op&Write == Write {
+				if event.HasWrite() {
 					modifyReceived.increment()
 				}
-				if event.Op&Chmod == Chmod {
+				if event.HasChmod() {
 					attribReceived.increment()
 				}
 				t.Logf("event received: %s", event)
@@ -1026,7 +1026,7 @@ func TestFsnotifyFakeSymlink(t *testing.T) {
 	go func() {
 		for ev := range watcher.Events {
 			t.Logf("event received: %s", ev)
-			if ev.Op&Create == Create {
+			if ev.HasCreate() {
 				createEventsReceived.increment()
 			} else {
 				otherEventsReceived.increment()

--- a/kqueue.go
+++ b/kqueue.go
@@ -276,7 +276,7 @@ func (w *Watcher) readEvents() {
 			w.mu.Unlock()
 			event := newEvent(path.name, mask)
 
-			if path.isDir && !(event.Op&Remove == Remove) {
+			if path.isDir && !event.HasRemove() {
 				// Double check to make sure the directory exists. This can happen when
 				// we do a rm -fr on a recursively watched folders and we receive a
 				// modification event first but the folder has been deleted and later
@@ -287,21 +287,21 @@ func (w *Watcher) readEvents() {
 				}
 			}
 
-			if event.Op&Rename == Rename || event.Op&Remove == Remove {
+			if event.HasRename() || event.HasRemove() {
 				w.Remove(event.Name)
 				w.mu.Lock()
 				delete(w.fileExists, event.Name)
 				w.mu.Unlock()
 			}
 
-			if path.isDir && event.Op&Write == Write && !(event.Op&Remove == Remove) {
+			if path.isDir && event.HasWrite() && !event.HasRemove() {
 				w.sendDirectoryChangeEvents(event.Name)
 			} else {
 				// Send the event on the Events channel
 				w.Events <- event
 			}
 
-			if event.Op&Remove == Remove {
+			if event.HasRemove() {
 				// Look for a file that may have overwritten this.
 				// For example, mv f1 f2 will delete f2, then create f2.
 				fileDir, _ := filepath.Split(event.Name)


### PR DESCRIPTION
This helps expose a simpler way to query the state of an `Event` without resorting to the bitwise query on the raw opcode.

I originally named these as `Is*` instead of `Has*`, but went with `Has*` since each `Event` can hold multiple states. So `Has` seemed more appropriate.

I have signed the Google CLA.