### PR TITLE
Update kqueue.go

### DIFF
--- a/kqueue.go
+++ b/kqueue.go
@@ -412,7 +412,7 @@ func (w *Watcher) internalWatch(name string, fileInfo os.FileInfo) error {
 		flags := w.dirFlags[name]
 		w.mu.Unlock()
 
-		flags |= syscall.NOTE_DELETE
+		flags |= syscall.NOTE_DELETE | syscall.NOTE_RENAME
 		return w.addWatch(name, flags)
 	}
 


### PR DESCRIPTION
if flags has no  syscall.NOTE_RENAME, subdir rename event will not notify.