### PR TITLE
switch to epoll_create1

### DIFF
--- a/inotify_poller.go
+++ b/inotify_poller.go
@@ -39,7 +39,7 @@ func newFdPoller(fd int) (*fdPoller, error) {
 	poller.fd = fd
 
 	// Create epoll fd
-	poller.epfd, errno = syscall.EpollCreate(1)
+	poller.epfd, errno = syscall.EpollCreate1(0)
 	if poller.epfd == -1 {
 		return nil, errno
 	}


### PR DESCRIPTION
Epoll_create was replaced with epoll_create1 in linux 2.6.27. The older
syscall isn't available on new architectures (such as arm64). Without this,
error: docker[1582]: syscall 1042 on kernel logs while docker fails to start.

CLA has been signed and code tested on linux (this code doesn't run anywhere else)
