### PR TITLE
Avoid infinite loops from symlinks cycles

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"sync/atomic"
@@ -1062,6 +1063,53 @@ func TestFsnotifyFakeSymlink(t *testing.T) {
 
 	// Try closing the fsnotify instance
 	t.Log("calling Close()")
+	watcher.Close()
+}
+
+func TestCyclicSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks don't work on Windows.")
+	}
+
+	watcher := newWatcher(t)
+
+	testDir := tempMkdir(t)
+	defer os.RemoveAll(testDir)
+
+	link := path.Join(testDir, "link")
+	if err := os.Symlink(".", link); err != nil {
+		t.Fatalf("could not make symlink: %v", err)
+	}
+	addWatch(t, watcher, testDir)
+
+	var createEventsReceived counter
+	go func() {
+		for ev := range watcher.Events {
+			if ev.Op&Create == Create {
+				createEventsReceived.increment()
+			}
+		}
+	}()
+
+	if err := os.Remove(link); err != nil {
+		t.Fatalf("Error removing link: %v", err)
+	}
+
+	// It would be nice to be able to expect a delete event here, but kqueue has
+	// no way for us to get events on symlinks themselves, because opening them
+	// opens an fd to the file to which they point.
+
+	if err := ioutil.WriteFile(link, []byte("foo"), 0700); err != nil {
+		t.Fatalf("could not make symlink: %v", err)
+	}
+
+	// We expect this event to be received almost immediately, but let's wait 500 ms to be sure
+	time.Sleep(500 * time.Millisecond)
+
+	if got := createEventsReceived.value(); got == 0 {
+		t.Errorf("want at least 1 create event got %v", got)
+	}
+
 	watcher.Close()
 }
 

--- a/kqueue.go
+++ b/kqueue.go
@@ -94,7 +94,8 @@ func (w *Watcher) Add(name string) error {
 	w.mu.Lock()
 	w.externalWatches[name] = true
 	w.mu.Unlock()
-	return w.addWatch(name, noteAllEvents)
+	_, err := w.addWatch(name, noteAllEvents)
+	return err
 }
 
 // Remove stops watching the the named file or directory (non-recursively).
@@ -153,7 +154,8 @@ var keventWaitTime = durationToTimespec(100 * time.Millisecond)
 
 // addWatch adds name to the watched file set.
 // The flags are interpreted as described in kevent(2).
-func (w *Watcher) addWatch(name string, flags uint32) error {
+// Returns the real path to the file which was added, if any, which may be different from the one passed in the case of symlinks.
+func (w *Watcher) addWatch(name string, flags uint32) (string, error) {
 	var isDir bool
 	// Make ./name and name equivalent
 	name = filepath.Clean(name)
@@ -161,7 +163,7 @@ func (w *Watcher) addWatch(name string, flags uint32) error {
 	w.mu.Lock()
 	if w.isClosed {
 		w.mu.Unlock()
-		return errors.New("kevent instance already closed")
+		return "", errors.New("kevent instance already closed")
 	}
 	watchfd, alreadyWatching := w.watches[name]
 	// We already have a watch, but we can still override flags.
@@ -173,17 +175,17 @@ func (w *Watcher) addWatch(name string, flags uint32) error {
 	if !alreadyWatching {
 		fi, err := os.Lstat(name)
 		if err != nil {
-			return err
+			return "", err
 		}
 
 		// Don't watch sockets.
 		if fi.Mode()&os.ModeSocket == os.ModeSocket {
-			return nil
+			return "", nil
 		}
 
 		// Don't watch named pipes.
 		if fi.Mode()&os.ModeNamedPipe == os.ModeNamedPipe {
-			return nil
+			return "", nil
 		}
 
 		// Follow Symlinks
@@ -195,18 +197,18 @@ func (w *Watcher) addWatch(name string, flags uint32) error {
 		if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
 			name, err = filepath.EvalSymlinks(name)
 			if err != nil {
-				return nil
+				return "", nil
 			}
 
 			fi, err = os.Lstat(name)
 			if err != nil {
-				return nil
+				return "", nil
 			}
 		}
 
 		watchfd, err = syscall.Open(name, openMode, 0700)
 		if watchfd == -1 {
-			return err
+			return "", err
 		}
 
 		isDir = fi.IsDir()
@@ -215,11 +217,12 @@ func (w *Watcher) addWatch(name string, flags uint32) error {
 	const registerAdd = syscall.EV_ADD | syscall.EV_CLEAR | syscall.EV_ENABLE
 	if err := register(w.kq, []int{watchfd}, registerAdd, flags); err != nil {
 		syscall.Close(watchfd)
-		return err
+		return "", err
 	}
 
 	if !alreadyWatching {
 		w.mu.Lock()
+		_, alreadyWatching = w.watches[name]
 		w.watches[name] = watchfd
 		w.paths[watchfd] = pathInfo{name: name, isDir: isDir}
 		w.mu.Unlock()
@@ -229,6 +232,7 @@ func (w *Watcher) addWatch(name string, flags uint32) error {
 		// Watch the directory if it has not been watched before,
 		// or if it was watched before, but perhaps only a NOTE_DELETE (watchDirectoryFiles)
 		w.mu.Lock()
+
 		watchDir := (flags&syscall.NOTE_WRITE) == syscall.NOTE_WRITE &&
 			(!alreadyWatching || (w.dirFlags[name]&syscall.NOTE_WRITE) != syscall.NOTE_WRITE)
 		// Store flags so this watch can be updated later
@@ -237,11 +241,11 @@ func (w *Watcher) addWatch(name string, flags uint32) error {
 
 		if watchDir {
 			if err := w.watchDirectoryFiles(name); err != nil {
-				return err
+				return "", err
 			}
 		}
 	}
-	return nil
+	return name, nil
 }
 
 // readEvents reads from kqueue and converts the received kevents into
@@ -364,7 +368,8 @@ func (w *Watcher) watchDirectoryFiles(dirPath string) error {
 
 	for _, fileInfo := range files {
 		filePath := filepath.Join(dirPath, fileInfo.Name())
-		if err := w.internalWatch(filePath, fileInfo); err != nil {
+		filePath, err = w.internalWatch(filePath, fileInfo)
+		if err != nil {
 			return err
 		}
 
@@ -399,7 +404,8 @@ func (w *Watcher) sendDirectoryChangeEvents(dirPath string) {
 		}
 
 		// like watchDirectoryFiles (but without doing another ReadDir)
-		if err := w.internalWatch(filePath, fileInfo); err != nil {
+		filePath, err = w.internalWatch(filePath, fileInfo)
+		if err != nil {
 			return
 		}
 
@@ -409,7 +415,7 @@ func (w *Watcher) sendDirectoryChangeEvents(dirPath string) {
 	}
 }
 
-func (w *Watcher) internalWatch(name string, fileInfo os.FileInfo) error {
+func (w *Watcher) internalWatch(name string, fileInfo os.FileInfo) (string, error) {
 	if fileInfo.IsDir() {
 		// mimic Linux providing delete events for subdirectories
 		// but preserve the flags used if currently watching subdirectory


### PR DESCRIPTION
The semenatics of using kqueue are already slightly different than
inotify, specifically that inotify will give you events for the symlink
itself whereas kqueue will only give events for the target of the
symlink. This preserves that behaviour, that symlinks don't get notified
on, but ensures that circular symlinks don't recurse forever.

This change pushes the resolved filename up through the stack so that
the fileExists map can be properly populated; not doing so would mean
that deleting a cyclical symlink and then replacing it with a file of
the same name would not notify for that file's creation (or subsequent
events) because we would believe that the file already existed.